### PR TITLE
feat(Designer): Added tooltip for tokenpicker in editors

### DIFF
--- a/libs/designer-ui/src/lib/editor/base/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/index.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@fluentui/react-components';
 import { RichTextToolbar } from '../../html/plugins/toolbar/RichTextToolbar';
 import type { TokenPickerMode } from '../../tokenpicker';
 import { useId } from '../../useId';
@@ -170,72 +171,81 @@ export const BaseEditor = ({
 
   const id = useId('msla-described-by-message');
   const TextPlugin = htmlEditor === 'rich-html' ? RichTextPlugin : PlainTextPlugin;
+  const forwardSlashSnippet = '/';
+
   return (
-    <>
-      <div className={className ?? 'msla-editor-container'} id={editorId} ref={containerRef} data-automation-id={dataAutomationId}>
-        {htmlEditor ? (
-          <RichTextToolbar
-            isRawText={htmlEditor === 'raw-html'}
-            isSwitchFromPlaintextBlocked={isSwitchFromPlaintextBlocked}
-            readonly={readonly}
-            setIsRawText={setIsValuePlaintext}
+    <Tooltip
+      relationship="label"
+      positioning={'below-start'}
+      content={`Press ${forwardSlashSnippet} to insert dynamic value or expression`}
+      visible={isEditorFocused}
+    >
+      <div>
+        <div className={className ?? 'msla-editor-container'} id={editorId} ref={containerRef} data-automation-id={dataAutomationId}>
+          {htmlEditor ? (
+            <RichTextToolbar
+              isRawText={htmlEditor === 'raw-html'}
+              isSwitchFromPlaintextBlocked={isSwitchFromPlaintextBlocked}
+              readonly={readonly}
+              setIsRawText={setIsValuePlaintext}
+            />
+          ) : null}
+          <TextPlugin
+            contentEditable={
+              <ContentEditable
+                spellCheck={false}
+                className={css('editor-input', readonly && 'readonly')}
+                ariaLabelledBy={labelId}
+                ariaDescribedBy={id}
+                tabIndex={0}
+                title={placeholder}
+              />
+            }
+            placeholder={
+              <span className="editor-placeholder" ref={placeholderRef}>
+                {placeholder}
+              </span>
+            }
+            ErrorBoundary={LexicalErrorBoundary}
           />
-        ) : null}
-        <TextPlugin
-          contentEditable={
-            <ContentEditable
-              spellCheck={false}
-              className={css('editor-input', readonly && 'readonly')}
-              ariaLabelledBy={labelId}
-              ariaDescribedBy={id}
-              tabIndex={0}
-              title={placeholder}
-            />
-          }
-          placeholder={
-            <span className="editor-placeholder" ref={placeholderRef}>
-              {placeholder}
-            </span>
-          }
-          ErrorBoundary={LexicalErrorBoundary}
-        />
-        <span id={id} hidden={true}>
-          {describedByMessage}
-        </span>
-        {treeView ? <TreeView /> : null}
-        {autoFocus ? <AutoFocus /> : null}
-        {history ? <History /> : null}
-        {autoLink ? <AutoLink /> : null}
-        {clearEditor ? <ClearEditor showButton={false} /> : null}
-        {singleValueSegment ? <SingleValueSegment /> : null}
-        {preventPropagation ? <PreventPropagationPlugin /> : null}
-        <FocusChangePlugin onFocus={handleFocus} onBlur={handleBlur} onClick={handleClick} />
-        <ReadOnly readonly={readonly} />
-        {tabbable ? null : <IgnoreTab />}
-        {htmlEditor === 'rich-html' ? null : <ArrowNavigation />}
-        {tokens ? (
-          <>
-            <InsertTokenNode />
-            <DeleteTokenNode />
-            <OpenTokenPicker openTokenPicker={openTokenPicker} />
-            <CloseTokenPicker closeTokenPicker={() => setIsTokenPickerOpened(false)} />
-            <TokenTypeAheadPlugin
-              openTokenPicker={openTokenPicker}
-              isEditorFocused={isEditorFocused}
-              hideTokenPickerOptions={tokenPickerButtonProps?.hideButtonOptions}
-            />
-          </>
-        ) : null}
-        {tokens ? <PastePlugin segmentMapping={tokenMapping} loadParameterValueFromString={loadParameterValueFromString} /> : null}
-        {htmlEditor && floatingAnchorElem ? (
-          <FloatingLinkEditorPlugin anchorElem={floatingAnchorElem} isMainEditorFocused={isEditorFocused} />
-        ) : null}
-        {children}
-        {tokens && isTokenPickerOpened ? getTokenPicker(editorId, labelId ?? '', tokenPickerMode, valueType) : null}
+          <span id={id} hidden={true}>
+            {describedByMessage}
+          </span>
+          {treeView ? <TreeView /> : null}
+          {autoFocus ? <AutoFocus /> : null}
+          {history ? <History /> : null}
+          {autoLink ? <AutoLink /> : null}
+          {clearEditor ? <ClearEditor showButton={false} /> : null}
+          {singleValueSegment ? <SingleValueSegment /> : null}
+          {preventPropagation ? <PreventPropagationPlugin /> : null}
+          <FocusChangePlugin onFocus={handleFocus} onBlur={handleBlur} onClick={handleClick} />
+          <ReadOnly readonly={readonly} />
+          {tabbable ? null : <IgnoreTab />}
+          {htmlEditor === 'rich-html' ? null : <ArrowNavigation />}
+          {tokens ? (
+            <>
+              <InsertTokenNode />
+              <DeleteTokenNode />
+              <OpenTokenPicker openTokenPicker={openTokenPicker} />
+              <CloseTokenPicker closeTokenPicker={() => setIsTokenPickerOpened(false)} />
+              <TokenTypeAheadPlugin
+                openTokenPicker={openTokenPicker}
+                isEditorFocused={isEditorFocused}
+                hideTokenPickerOptions={tokenPickerButtonProps?.hideButtonOptions}
+              />
+            </>
+          ) : null}
+          {tokens ? <PastePlugin segmentMapping={tokenMapping} loadParameterValueFromString={loadParameterValueFromString} /> : null}
+          {htmlEditor && floatingAnchorElem ? (
+            <FloatingLinkEditorPlugin anchorElem={floatingAnchorElem} isMainEditorFocused={isEditorFocused} />
+          ) : null}
+          {children}
+          {tokens && isTokenPickerOpened ? getTokenPicker(editorId, labelId ?? '', tokenPickerMode, valueType) : null}
+        </div>
+        {tokens && isEditorFocused && !isTokenPickerOpened
+          ? createPortal(<TokenPickerButton {...tokenPickerButtonProps} openTokenPicker={openTokenPicker} />, document.body)
+          : null}
       </div>
-      {tokens && isEditorFocused && !isTokenPickerOpened
-        ? createPortal(<TokenPickerButton {...tokenPickerButtonProps} openTokenPicker={openTokenPicker} />, document.body)
-        : null}
-    </>
+    </Tooltip>
   );
 };

--- a/libs/designer-ui/src/lib/editor/base/index.tsx
+++ b/libs/designer-ui/src/lib/editor/base/index.tsx
@@ -31,6 +31,7 @@ import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useIntl } from 'react-intl';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 
 export interface ChangeState {
   value: ValueSegment[];
@@ -173,12 +174,16 @@ export const BaseEditor = ({
   const TextPlugin = htmlEditor === 'rich-html' ? RichTextPlugin : PlainTextPlugin;
   const forwardSlashSnippet = '/';
 
+  const [editor] = useLexicalComposerContext();
+  const editorHasContent = !!(editor._rootElement?.textContent && editor._rootElement?.textContent.length > 0);
+  const tooltipVisible = isEditorFocused && !editorHasContent;
+
   return (
     <Tooltip
       relationship="label"
       positioning={'below-start'}
-      content={`Press ${forwardSlashSnippet} to insert dynamic value or expression`}
-      visible={isEditorFocused}
+      content={`Press '${forwardSlashSnippet}' to insert dynamic value or expression`}
+      visible={tooltipVisible}
     >
       <div>
         <div className={className ?? 'msla-editor-container'} id={editorId} ref={containerRef} data-automation-id={dataAutomationId}>
@@ -242,7 +247,7 @@ export const BaseEditor = ({
           {children}
           {tokens && isTokenPickerOpened ? getTokenPicker(editorId, labelId ?? '', tokenPickerMode, valueType) : null}
         </div>
-        {tokens && isEditorFocused && !isTokenPickerOpened
+        {tokens && isEditorFocused
           ? createPortal(<TokenPickerButton {...tokenPickerButtonProps} openTokenPicker={openTokenPicker} />, document.body)
           : null}
       </div>


### PR DESCRIPTION
## Requirement Checklist

* [x] The commit message follows our guidelines
* [x] Tests for the changes have been added (for bug fixes or features)
* [x] Docs have been added or updated (for bug fixes or features)

## Type of Change

* [ ] Bug fix
* [x] Feature
* [ ] Other

## Current Behavior

<!-- You can use this section to: link to an open issue, share the repro of a bug that exists today, or describe current functionality. -->

Currently, we can use a keyboard shortcut to invoke the TokenPicker using the '/' key. However, most users are unaware that this keyboard shortcut exists. 

## New Behavior

<!-- For features, describe the new behavior. For bugs, this section can be deleted, or you can optionally describe any new behavior that occurs now that the bug has been addressed. -->

This feature (linked below) invokes adding a tooltip to the base editor underneath text editors in LogicApps to inform users that they can click on the '/' key to invoke TokenPicker.

[Feature 28535677](https://msazure.visualstudio.com/One/_workitems/edit/28535677): [NPS] Increase visibility to keyboard shortcut to invoke token picker

## Impact of Change

<!-- If this PR has breaking changes for downstream consumers, check the box below. If you check the box, please provide information about the breaking changes as well. -->

Improves UX for LogicApps and Power Automate users.

* [ ] **This is a breaking change.**

## Screenshots or Videos (if applicable)

<!-- Paste screenshots, videos, or GIFs of the change if it is has a visual impact. -->

Tooltip appears when text-based editors are clicked (aka 'focused' based on LAUX code terminology):

![image](https://github.com/user-attachments/assets/7342827e-42a2-4194-9f8c-f54ce804671a)

Tooltip stops being visible when the user starts typing even if the editor is still in focus:

![image](https://github.com/user-attachments/assets/2b3053e0-071c-4239-8beb-e07802687bd7)

Tooltip stops being visible if an editor within an action already has content; we can presume that the tooltip will help most when users are adding new actions to an existing flow or new editors to an existing action.

Additional info: The tooltip does not block other editors once the user starts typing, like the dictionary editor below. This detail ensures that no editors are covered by the tooltip once the user starts to type (or take action on the information in the tooltip):

![image](https://github.com/user-attachments/assets/61e7aa03-39e8-46d2-8c7d-a319478878cb)

![image](https://github.com/user-attachments/assets/4e8547a6-01cb-4837-abdc-75653933cd6b)




